### PR TITLE
feat: add professional status to verify-prof API

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Di seguito è riportata la prima versione dello schema dei dati relativi all'att
 | validFrom | Data di Scadenza | NO | DATA |  |
 | validThrough | Data di Rilascio | NO | DATA |  |
 | identifier | Seriale carta | NO | ALFANUMERICO |  |
+| status | Stato professionale (ATTIVO, SOSPESO, CANCELLATO, RADIATO) | SI | ALFANUMERICO |  |
 | pensionFund | Numero Ente Nazionale di Previdenza | NO | ALFANUMERICO |  |
 
 Lo schema dati sopra riportato è da intendersi come proposta iniziale ed è aperto a modifiche e miglioramenti.

--- a/openapi/examples/verifica_professionista.yaml
+++ b/openapi/examples/verifica_professionista.yaml
@@ -1,6 +1,6 @@
 openapi: 3.0.0
 info:
-  version: "1.0.0"
+  version: "1.1.0"
   title: Federazione Ordine Professioni Sanitarie - Verifica iscrizione professionista
   description: |
     API per la verifica dell'iscrizione di un professionista sanitario
@@ -14,9 +14,9 @@ info:
 
       Il servizio offre un'opzione di verifica dell'iscrizione di un professionista
       all'Albo della Federazione Nazionale dato in input il `anpr_id` o il `tax_code`.
-      La risposta è di tipo booleano:
-      - `true`: il professionista è iscritto all'Albo,
-      - `false`: il professionista non è iscritto all'Albo.
+      La risposta è di tipo booleano integrata dallo stato:
+      - `is_registered`: indica se il professionista è presente nell'Albo,
+      - `status`: indica lo stato puntuale (ATTIVO, SOSPESO, etc.).
   contact:
     name: Federazione - API Support
     email: api-support@example-federation.it
@@ -148,12 +148,19 @@ paths:
                 properties:
                   is_registered:
                     type: boolean
-                    description: Indica se il professionista è iscritto all'Albo.
+                    description: |
+                      Indica se il professionista è attualmente presente nell'Albo, 
+                      indipendentemente dallo stato.
+                  status:
+                    type: string
+                    description: Stato corrente dell'iscrizione all'Albo.
+                    enum: [ATTIVO, SOSPESO, CANCELLATO, RADIATO]
                   request_id:
                     type: string
                     description: Identificativo univoco della richiesta.
                 required:
                   - is_registered
+                  - status
                   - request_id
           headers:
             Cache-Control:


### PR DESCRIPTION
Questa PR aggiunge il campo 'status' (ATTIVO, SOSPESO, CANCELLATO, RADIATO) all'API di verifica professionista per garantire una verifica completa dell'abilitazione all'esercizio. Mantiene la retrocompatibilità con 'is_registered'.