### PR TITLE
docs: flatten query parameters for GovWay compatibility

### DIFF
--- a/openapi/examples/govway/accertamento_professionista.yaml
+++ b/openapi/examples/govway/accertamento_professionista.yaml
@@ -1,0 +1,392 @@
+openapi: 3.0.0
+info:
+  version: "1.0.3"
+  title: Federazione Ordine Professioni Sanitarie - Accertamento iscrizione professionista
+  description: |
+    API per l'accertamento dell'iscrizione di un professionista sanitario
+    all'Albo della Federazione Nazionale.
+
+    Parametri di ricerca (alternativi):
+    - `anpr_id` (ID univoco ANPR)
+    - `tax_code` (Codice Fiscale)
+    - `given_name` + `family_name` (Nome e Cognome)
+
+    Regole di utilizzo:
+    - `anpr_id`: restituisce un risultato univoco (nessuna omocodia)
+    - `tax_code`: può restituire più risultati in caso di omocodie
+    - `given_name` + `family_name`: può restituire più risultati
+  contact:
+    name: Federazione - API Support
+    email: api-support@example-federation.it
+  termsOfService: "https://portale.example-federation.it/cerca-prof/"
+  x-api-id: FPROF-01
+  x-summary: Accertamento iscrizione professionista sanitario
+
+servers:
+  - url: "https://api.example-federation.it/govway/rest/in/Ente/FPROF-01/v1"
+    description: Ambiente di produzione - Accertamento iscrizione professionista
+
+paths:
+  /status:
+    get:
+      security: []
+      tags:
+        - status
+      summary: Verifica stato del servizio
+      description: |
+        Endpoint di health check per verificare che il servizio sia attivo e pronto
+        a rispondere alle richieste.
+
+        Restituisce HTTP 200 se il servizio è disponibile.
+      operationId: serviceStatus
+      responses:
+        "200":
+          description: Servizio disponibile
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            Cache-Control:
+              $ref: "#/components/headers/CacheControlHeader"
+            RateLimit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            RateLimit-Reset:
+              $ref: "#/components/headers/RateLimitResetHeader"
+            Agid-JWT-Signature:
+              $ref: "#/components/headers/AgidJWTSignatureHeader"
+            Digest:
+              $ref: "#/components/headers/DigestHeader"
+        "429":
+          description: Too Many Requests
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            RateLimit-Reset:
+              $ref: "#/components/headers/RateLimitResetHeader"
+            Agid-JWT-Signature:
+              $ref: "#/components/headers/AgidJWTSignatureHeader"
+            Digest:
+              $ref: "#/components/headers/DigestHeader"
+        "503":
+          description: Service Unavailable
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            Retry-After:
+              $ref: "#/components/headers/RetryAfterHeader"
+            Agid-JWT-Signature:
+              $ref: "#/components/headers/AgidJWTSignatureHeader"
+            Digest:
+              $ref: "#/components/headers/DigestHeader"
+
+  /check-prof:
+    get:
+      tags:
+        - professionista
+      summary: Accertamento iscrizione professionista
+      description: |
+        API per accertare l'iscrizione all'Albo di un professionista.
+
+        Fornire esattamente uno dei criteri di ricerca (solo tax_code, o solo anpr_id, o la coppia given_name/family_name).
+      operationId: checkProfessionista
+      parameters:
+        - name: anpr_id
+          in: query
+          required: false
+          description: ID univoco ANPR del professionista.
+          schema:
+            type: string
+            example: "AB123456C"
+            minLength: 9
+            maxLength: 9
+        - name: tax_code
+          in: query
+          required: false
+          description: Tax Identification Number / Codice Fiscale
+          schema:
+            type: string
+            example: RSSMRA80A01F205D
+            pattern: '^(?:^(?:[A-Z][AEIOU][AEIOUX]|[B-DF-HJ-NP-TV-Z]{2}[A-Z]){2}(?:[\dLMNP-V]{2}(?:[A-EHLMPR-T](?:[04LQ][1-9MNP-V]|[15MR][\dLMNP-V]|[26NS][0-8LMNP-U])|[DHPS][37PT][0L]|[ACELMRT][37PT][01LM]|[AC-EHLMPR-T][26NS][9V])|(?:[02468LNQSU][048LQU]|[13579MPRTV][26NS])B[26NS][9V])(?:[A-MZ][1-9MNP-V][\dLMNP-V]{2}|[A-M][0L](?:[1-9MNP-V][\dLMNP-V]|[0L][1-9MNP-V]))[A-Z]$)'
+            minLength: 16
+            maxLength: 16
+        - name: given_name
+          in: query
+          required: false
+          description: Nome del professionista.
+          schema:
+            type: string
+        - name: family_name
+          in: query
+          required: false
+          description: Cognome del professionista.
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Ricerca eseguita con successo
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  result:
+                    type: array
+                    description: Elenco dei professionisti trovati.
+                    items:
+                      $ref: "#/components/schemas/Professionista"
+                  request_id:
+                    type: string
+                    description: Identificativo univoco della richiesta.
+                required:
+                  - result
+                  - request_id
+          headers:
+            Cache-Control:
+              $ref: "#/components/headers/CacheControlHeader"
+            RateLimit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            RateLimit-Reset:
+              $ref: "#/components/headers/RateLimitResetHeader"
+            Agid-JWT-Signature:
+              $ref: "#/components/headers/AgidJWTSignatureHeader"
+            Digest:
+              $ref: "#/components/headers/DigestHeader"
+        "400":
+          description: Parametri di ricerca non validi o mancanti
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            RateLimit-Reset:
+              $ref: "#/components/headers/RateLimitResetHeader"
+            Agid-JWT-Signature:
+              $ref: "#/components/headers/AgidJWTSignatureHeader"
+            Digest:
+              $ref: "#/components/headers/DigestHeader"
+        "401":
+          description: Unauthorized
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            RateLimit-Reset:
+              $ref: "#/components/headers/RateLimitResetHeader"
+            Agid-JWT-Signature:
+              $ref: "#/components/headers/AgidJWTSignatureHeader"
+            Digest:
+              $ref: "#/components/headers/DigestHeader"
+        "429":
+          description: Too Many Requests
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            Retry-After:
+              $ref: "#/components/headers/RetryAfterHeader"
+            Agid-JWT-Signature:
+              $ref: "#/components/headers/AgidJWTSignatureHeader"
+            Digest:
+              $ref: "#/components/headers/DigestHeader"
+        "500":
+          description: Internal Server Error.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            Retry-After:
+              $ref: "#/components/headers/RetryAfterHeader"
+        "503":
+          description: Service Unavailable
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            Retry-After:
+              $ref: "#/components/headers/RetryAfterHeader"
+            Agid-JWT-Signature:
+              $ref: "#/components/headers/AgidJWTSignatureHeader"
+            Digest:
+              $ref: "#/components/headers/DigestHeader"
+
+tags:
+  - name: status
+    description: Endpoint di health check dell'API.
+  - name: professionista
+    description: API relative ai professionisti iscritti all'Albo.
+
+components:
+  headers:
+    CacheControlHeader:
+      schema:
+        type: string
+        enum:
+          - no-store
+      description: no-store
+    RateLimitLimitHeader:
+      schema:
+        type: integer
+        format: int32
+        minimum: 0
+      description: Numero massimo richieste nell'intervallo di tempo.
+    RateLimitRemainingHeader:
+      schema:
+        type: integer
+        format: int32
+        minimum: 0
+      description: Richieste rimanenti nell'intervallo di tempo.
+    RateLimitResetHeader:
+      schema:
+        type: integer
+        format: int32
+        minimum: 0
+      description: UTC epoch in secondi, corrispondente a quando la finestra riferita al rate limit corrente effettuerà il reset.
+    RetryAfterHeader:
+      schema:
+        type: integer
+        format: int32
+        minimum: 0
+      description: Secondi da attendere prima di ricevere un'ulteriore risposta.
+    AgidJWTSignatureHeader:
+      schema:
+        type: string
+        format: JWT
+        example: eyJhbGc...1VrXfKTx-CUVz_puiwqkBhulrNKj2fA
+      description: JWT contenente la firma della risposta secondo il pattern INTEGRITY_REST_02 del ModI.
+    DigestHeader:
+      schema:
+        type: string
+        example: SHA-256=72e18bdddf13c911b4dd562ee21979a5c9f235c3a01bd1426e857d8c1a282f41
+      description: Digest del payload del messaggio di risposta secondo il pattern INTEGRITY_REST_02 del ModI.
+
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
+  schemas:
+    Problem:
+      type: object
+      title: Dettaglio esito chiamata
+      properties:
+        type:
+          type: string
+          description: Tipologia di errore o messaggio.
+        title:
+          type: string
+          description: Titolo sintetico dell'errore.
+        status:
+          type: integer
+          format: int32
+          minimum: 100
+          maximum: 599
+          description: Codice di stato HTTP associato.
+        detail:
+          type: string
+          description: Descrizione dettagliata dell'errore.
+        result:
+          type: object
+          description: Eventuale payload specifico dell'errore.
+        request_id:
+          type: string
+          description: Identificativo univoco della richiesta.
+      required:
+        - title
+        - status
+        - detail
+
+    Person:
+      type: object
+      x-jsonld-context:
+        CPV: "https://w3id.org/italia/onto/CPV/"
+        tax_code: "CPV:taxCode"
+        given_name: "CPV:givenName"
+        family_name: "CPV:familyName"
+        anpr_id: "CPV:personID"
+      x-jsonld-type: "CPV:Person"
+      title: Persona generica
+      properties:
+        anpr_id:
+          type: string
+          description: ID univoco ANPR del professionista.
+          example: "AB123456C"
+          minLength: 9
+          maxLength: 9
+        tax_code:
+          type: string
+          description: Tax Identification Number / Codice Fiscale
+          example: RSSMRA80A01F205D
+          pattern: '^(?:^(?:[A-Z][AEIOU][AEIOUX]|[B-DF-HJ-NP-TV-Z]{2}[A-Z]){2}(?:[\dLMNP-V]{2}(?:[A-EHLMPR-T](?:[04LQ][1-9MNP-V]|[15MR][\dLMNP-V]|[26NS][0-8LMNP-U])|[DHPS][37PT][0L]|[ACELMRT][37PT][01LM]|[AC-EHLMPR-T][26NS][9V])|(?:[02468LNQSU][048LQU]|[13579MPRTV][26NS])B[26NS][9V])(?:[A-MZ][1-9MNP-V][\dLMNP-V]{2}|[A-M][0L](?:[1-9MNP-V][\dLMNP-V]|[0L][1-9MNP-V]))[A-Z]$)'
+          minLength: 16
+          maxLength: 16
+        given_name:
+          type: string
+          description: Nome del professionista.
+          example: MARIO
+        family_name:
+          type: string
+          description: Cognome del professionista.
+          example: ROSSI
+      required:
+        - anpr_id
+        - tax_code
+        - family_name
+    Professionista:
+      x-jsonld-context:
+        CPV: "https://w3id.org/italia/onto/CPV/"
+      allOf:
+        - $ref: "#/components/schemas/Person"
+        - type: object
+          title: Professionista iscritto all'Albo
+          properties:
+            province:
+              type: string
+              description: Sigla della provincia dell'Ordine di iscrizione.
+              example: RM
+            ordine:
+              type: string
+              description: Denominazione dell'Ordine territoriale.
+              example: Ordine Provinciale di Roma della Professione Sanitaria
+            albo:
+              type: string
+              description: Tipo di Albo della professione sanitaria.
+              example: PROFESSIONE_SANITARIA
+            data_iscrizione:
+              type: string
+              format: date
+              description: Data di iscrizione del professionista all'Albo (formato ISO 8601 YYYY-MM-DD).
+              example: "2000-01-01"
+          required:
+            - province
+            - ordine
+            - albo
+            - data_iscrizione
+
+security:
+  - bearerAuth: []

--- a/openapi/examples/govway/verifica_iscrizione_professionista.yaml
+++ b/openapi/examples/govway/verifica_iscrizione_professionista.yaml
@@ -1,0 +1,311 @@
+openapi: 3.0.0
+info:
+  version: "1.0.0"
+  title: Federazione Ordine Professioni Sanitarie - Verifica iscrizione professionista
+  description: |
+    API per la verifica dell'iscrizione di un professionista sanitario
+    all'Albo della Federazione Nazionale.
+
+    Parametri di ricerca (alternativi):
+    - `anpr_id` (ID univoco ANPR)
+    - `tax_code` (Codice Fiscale)
+
+    Regole di utilizzo:
+      Il servizio offre un'opzione di verifica dell'iscrizione di un professionista
+      all'Albo della Federazione Nazionale dato in input l' `anpr_id` o il `tax_code`.
+      La risposta è di tipo booleano:
+      - `is_registered`: Certifica che il professionista è iscritto all'Albo e che la sua posizione risulta attiva (non sospesa, radiata o cancellata).
+  contact:
+    name: Federazione - API Support
+    email: api-support@example-federation.it
+  termsOfService: "https://portale.example-federation.it/cerca-prof/"
+  x-api-id: FPROF-03
+  x-summary: Verifica iscrizione professionista sanitario
+
+servers:
+  - url: "https://api.example-federation.it/govway/rest/in/Ente/FPROF-03/v1"
+    description: Ambiente di produzione - Verifica iscrizione professionista
+
+paths:
+  /status:
+    get:
+      security: []
+      tags:
+        - status
+      summary: Verifica stato del servizio
+      description: |
+        Endpoint di health check per verificare che il servizio sia attivo e pronto
+        a rispondere alle richieste.
+
+        Restituisce HTTP 200 se il servizio è disponibile.
+      operationId: serviceStatus
+      responses:
+        "200":
+          description: Servizio disponibile
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            Cache-Control:
+              $ref: "#/components/headers/CacheControlHeader"
+            RateLimit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            RateLimit-Reset:
+              $ref: "#/components/headers/RateLimitResetHeader"
+            Agid-JWT-Signature:
+              $ref: "#/components/headers/AgidJWTSignatureHeader"
+            Digest:
+              $ref: "#/components/headers/DigestHeader"
+        "429":
+          description: Too Many Requests
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            RateLimit-Reset:
+              $ref: "#/components/headers/RateLimitResetHeader"
+            Agid-JWT-Signature:
+              $ref: "#/components/headers/AgidJWTSignatureHeader"
+            Digest:
+              $ref: "#/components/headers/DigestHeader"
+        "503":
+          description: Service Unavailable
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            Retry-After:
+              $ref: "#/components/headers/RetryAfterHeader"
+            Agid-JWT-Signature:
+              $ref: "#/components/headers/AgidJWTSignatureHeader"
+            Digest:
+              $ref: "#/components/headers/DigestHeader"
+
+  /verify-prof:
+    get:
+      tags:
+        - professionista
+      summary: Verifica iscrizione professionista
+      description: |
+        API per verificare l'iscrizione all'Albo di un professionista.
+
+        Fornire esattamente uno dei parametri di ricerca.
+      operationId: verifyProfessionista
+      parameters:
+        - name: anpr_id
+          in: query
+          required: false
+          description: ID univoco ANPR del professionista.
+          schema:
+            type: string
+            example: "AB123456C"
+            minLength: 9
+            maxLength: 9
+        - name: tax_code
+          in: query
+          required: false
+          description: Tax Identification Number / Codice Fiscale
+          schema:
+            type: string
+            example: RSSMRA80A01F205D
+            pattern: '^(?:^(?:[A-Z][AEIOU][AEIOUX]|[B-DF-HJ-NP-TV-Z]{2}[A-Z]){2}(?:[\dLMNP-V]{2}(?:[A-EHLMPR-T](?:[04LQ][1-9MNP-V]|[15MR][\dLMNP-V]|[26NS][0-8LMNP-U])|[DHPS][37PT][0L]|[ACELMRT][37PT][01LM]|[AC-EHLMPR-T][26NS][9V])|(?:[02468LNQSU][048LQU]|[13579MPRTV][26NS])B[26NS][9V])(?:[A-MZ][1-9MNP-V][\dLMNP-V]{2}|[A-M][0L](?:[1-9MNP-V][\dLMNP-V]|[0L][1-9MNP-V]))[A-Z]$)'
+            minLength: 16
+            maxLength: 16
+      responses:
+        "200":
+          description: Ricerca eseguita con successo
+          content:
+            application/json:
+              schema:
+                type: object
+                description: Professionista iscritto (stato obbligatorio)
+                properties:
+                  is_registered:
+                    type: boolean
+                    description: Certifica che il professionista è iscritto all'Albo e che la sua posizione risulta attiva (non sospesa, radiata o cancellata).
+                  request_id:
+                    type: string
+                    description: Identificativo univoco della richiesta.
+                required:
+                  - is_registered
+          headers:
+            Cache-Control:
+              $ref: "#/components/headers/CacheControlHeader"
+            RateLimit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            RateLimit-Reset:
+              $ref: "#/components/headers/RateLimitResetHeader"
+            Agid-JWT-Signature:
+              $ref: "#/components/headers/AgidJWTSignatureHeader"
+            Digest:
+              $ref: "#/components/headers/DigestHeader"
+        "400":
+          description: Parametri di ricerca non validi o mancanti
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            RateLimit-Reset:
+              $ref: "#/components/headers/RateLimitResetHeader"
+            Agid-JWT-Signature:
+              $ref: "#/components/headers/AgidJWTSignatureHeader"
+            Digest:
+              $ref: "#/components/headers/DigestHeader"
+        "401":
+          description: Unauthorized
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            RateLimit-Reset:
+              $ref: "#/components/headers/RateLimitResetHeader"
+            Agid-JWT-Signature:
+              $ref: "#/components/headers/AgidJWTSignatureHeader"
+            Digest:
+              $ref: "#/components/headers/DigestHeader"
+        "429":
+          description: Too Many Requests
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            Retry-After:
+              $ref: "#/components/headers/RetryAfterHeader"
+            Agid-JWT-Signature:
+              $ref: "#/components/headers/AgidJWTSignatureHeader"
+            Digest:
+              $ref: "#/components/headers/DigestHeader"
+        "500":
+          description: Internal Server Error.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            Retry-After:
+              $ref: "#/components/headers/RetryAfterHeader"
+        "503":
+          description: Service Unavailable
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            Retry-After:
+              $ref: "#/components/headers/RetryAfterHeader"
+            Agid-JWT-Signature:
+              $ref: "#/components/headers/AgidJWTSignatureHeader"
+            Digest:
+              $ref: "#/components/headers/DigestHeader"
+
+tags:
+  - name: status
+    description: Endpoint di health check dell'API.
+  - name: professionista
+    description: API relative ai professionisti iscritti all'Albo.
+
+components:
+  headers:
+    CacheControlHeader:
+      schema:
+        type: string
+        enum:
+          - no-store
+      description: no-store
+    RateLimitLimitHeader:
+      schema:
+        type: integer
+        format: int32
+        minimum: 0
+      description: Numero massimo richieste nell'intervallo di tempo.
+    RateLimitRemainingHeader:
+      schema:
+        type: integer
+        format: int32
+        minimum: 0
+      description: Richieste rimanenti nell'intervallo di tempo.
+    RateLimitResetHeader:
+      schema:
+        type: integer
+        format: int32
+        minimum: 0
+      description: UTC epoch in secondi, corrispondente a quando la finestra riferita al rate limit corrente effettuerà il reset.
+    RetryAfterHeader:
+      schema:
+        type: integer
+        format: int32
+        minimum: 0
+      description: Secondi da attendere prima di ricevere un'ulteriore risposta.
+    AgidJWTSignatureHeader:
+      schema:
+        type: string
+        format: JWT
+        example: eyJhbGc...1VrXfKTx-CUVz_puiwqkBhulrNKj2fA
+      description: JWT contenente la firma della risposta secondo il pattern INTEGRITY_REST_02 del ModI.
+    DigestHeader:
+      schema:
+        type: string
+        example: SHA-256=72e18bdddf13c911b4dd562ee21979a5c9f235c3a01bd1426e857d8c1a282f41
+      description: Digest del payload del messaggio di risposta secondo il pattern INTEGRITY_REST_02 del ModI.
+
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
+  schemas:
+    Problem:
+      type: object
+      title: Dettaglio esito chiamata
+      properties:
+        type:
+          type: string
+          description: Tipologia di errore o messaggio.
+        title:
+          type: string
+          description: Titolo sintetico dell'errore.
+        status:
+          type: integer
+          format: int32
+          minimum: 100
+          maximum: 599
+          description: Codice di stato HTTP associato.
+        detail:
+          type: string
+          description: Descrizione dettagliata dell'errore.
+        result:
+          type: object
+          description: Eventuale payload specifico dell'errore.
+        request_id:
+          type: string
+          description: Identificativo univoco della richiesta.
+      required:
+        - title
+        - status
+        - detail
+
+security:
+  - bearerAuth: []

--- a/openapi/examples/govway/verifica_stato_professionista.yaml
+++ b/openapi/examples/govway/verifica_stato_professionista.yaml
@@ -1,0 +1,312 @@
+openapi: 3.0.0
+info:
+  version: "1.2.0"
+  title: Federazione Ordine Professioni Sanitarie - Verifica stato iscrizione professionista
+  description: |
+    API per la verifica dello stato dell'iscrizione di un professionista sanitario
+    all'Albo della Federazione Nazionale.
+
+    Parametri di ricerca (alternativi):
+    - `anpr_id` (ID univoco ANPR)
+    - `tax_code` (Codice Fiscale)
+
+    Regole di utilizzo:
+      Il servizio offre un'opzione di verifica dell'iscrizione di un professionista
+      all'Albo della Federazione Nazionale dato in input l' `anpr_id` o il `tax_code`.
+      La risposta restituisce lo stato dell'iscrizione:
+      - `status`: indica lo stato puntuale (ATTIVO, SOSPESO, NON_ISCRITTO, etc.).
+  contact:
+    name: Federazione - API Support
+    email: api-support@example-federation.it
+  termsOfService: "https://portale.example-federation.it/cerca-prof/"
+  x-api-id: FPROF-02
+  x-summary: Verifica iscrizione professionista sanitario
+
+servers:
+  - url: "https://api.example-federation.it/govway/rest/in/Ente/FPROF-02/v1"
+    description: Ambiente di produzione - Verifica iscrizione professionista
+
+paths:
+  /status:
+    get:
+      security: []
+      tags:
+        - status
+      summary: Verifica stato del servizio
+      description: |
+        Endpoint di health check per verificare che il servizio sia attivo e pronto
+        a rispondere alle richieste.
+
+        Restituisce HTTP 200 se il servizio è disponibile.
+      operationId: serviceStatus
+      responses:
+        "200":
+          description: Servizio disponibile
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            Cache-Control:
+              $ref: "#/components/headers/CacheControlHeader"
+            RateLimit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            RateLimit-Reset:
+              $ref: "#/components/headers/RateLimitResetHeader"
+            Agid-JWT-Signature:
+              $ref: "#/components/headers/AgidJWTSignatureHeader"
+            Digest:
+              $ref: "#/components/headers/DigestHeader"
+        "429":
+          description: Too Many Requests
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            RateLimit-Reset:
+              $ref: "#/components/headers/RateLimitResetHeader"
+            Agid-JWT-Signature:
+              $ref: "#/components/headers/AgidJWTSignatureHeader"
+            Digest:
+              $ref: "#/components/headers/DigestHeader"
+        "503":
+          description: Service Unavailable
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            Retry-After:
+              $ref: "#/components/headers/RetryAfterHeader"
+            Agid-JWT-Signature:
+              $ref: "#/components/headers/AgidJWTSignatureHeader"
+            Digest:
+              $ref: "#/components/headers/DigestHeader"
+
+  /verify-prof:
+    get:
+      tags:
+        - professionista
+      summary: Verifica iscrizione professionista
+      description: |
+        API per verificare l'iscrizione all'Albo di un professionista.
+
+        Fornire esattamente uno dei parametri di ricerca.
+      operationId: verifyProfessionista
+      parameters:
+        - name: anpr_id
+          in: query
+          required: false
+          description: ID univoco ANPR del professionista.
+          schema:
+            type: string
+            example: "AB123456C"
+            minLength: 9
+            maxLength: 9
+        - name: tax_code
+          in: query
+          required: false
+          description: Tax Identification Number / Codice Fiscale
+          schema:
+            type: string
+            example: RSSMRA80A01F205D
+            pattern: '^(?:^(?:[A-Z][AEIOU][AEIOUX]|[B-DF-HJ-NP-TV-Z]{2}[A-Z]){2}(?:[\dLMNP-V]{2}(?:[A-EHLMPR-T](?:[04LQ][1-9MNP-V]|[15MR][\dLMNP-V]|[26NS][0-8LMNP-U])|[DHPS][37PT][0L]|[ACELMRT][37PT][01LM]|[AC-EHLMPR-T][26NS][9V])|(?:[02468LNQSU][048LQU]|[13579MPRTV][26NS])B[26NS][9V])(?:[A-MZ][1-9MNP-V][\dLMNP-V]{2}|[A-M][0L](?:[1-9MNP-V][\dLMNP-V]|[0L][1-9MNP-V]))[A-Z]$)'
+            minLength: 16
+            maxLength: 16
+      responses:
+        "200":
+          description: Ricerca eseguita con successo
+          content:
+            application/json:
+              schema:
+                type: object
+                description: Professionista iscritto (stato obbligatorio)
+                properties:
+                  status:
+                    type: string
+                    description: Stato corrente dell'iscrizione all'Albo.
+                    enum: [ATTIVO, SOSPESO, CANCELLATO, RADIATO, NON_ISCRITTO]
+                  request_id:
+                    type: string
+                    description: Identificativo univoco della richiesta.
+                required:
+                  - status
+          headers:
+            Cache-Control:
+              $ref: "#/components/headers/CacheControlHeader"
+            RateLimit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            RateLimit-Reset:
+              $ref: "#/components/headers/RateLimitResetHeader"
+            Agid-JWT-Signature:
+              $ref: "#/components/headers/AgidJWTSignatureHeader"
+            Digest:
+              $ref: "#/components/headers/DigestHeader"
+        "400":
+          description: Parametri di ricerca non validi o mancanti
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            RateLimit-Reset:
+              $ref: "#/components/headers/RateLimitResetHeader"
+            Agid-JWT-Signature:
+              $ref: "#/components/headers/AgidJWTSignatureHeader"
+            Digest:
+              $ref: "#/components/headers/DigestHeader"
+        "401":
+          description: Unauthorized
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            RateLimit-Limit:
+              $ref: "#/components/headers/RateLimitLimitHeader"
+            RateLimit-Remaining:
+              $ref: "#/components/headers/RateLimitRemainingHeader"
+            RateLimit-Reset:
+              $ref: "#/components/headers/RateLimitResetHeader"
+            Agid-JWT-Signature:
+              $ref: "#/components/headers/AgidJWTSignatureHeader"
+            Digest:
+              $ref: "#/components/headers/DigestHeader"
+        "429":
+          description: Too Many Requests
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            Retry-After:
+              $ref: "#/components/headers/RetryAfterHeader"
+            Agid-JWT-Signature:
+              $ref: "#/components/headers/AgidJWTSignatureHeader"
+            Digest:
+              $ref: "#/components/headers/DigestHeader"
+        "500":
+          description: Internal Server Error.
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            Retry-After:
+              $ref: "#/components/headers/RetryAfterHeader"
+        "503":
+          description: Service Unavailable
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/Problem"
+          headers:
+            Retry-After:
+              $ref: "#/components/headers/RetryAfterHeader"
+            Agid-JWT-Signature:
+              $ref: "#/components/headers/AgidJWTSignatureHeader"
+            Digest:
+              $ref: "#/components/headers/DigestHeader"
+
+tags:
+  - name: status
+    description: Endpoint di health check dell'API.
+  - name: professionista
+    description: API relative ai professionisti iscritti all'Albo.
+
+components:
+  headers:
+    CacheControlHeader:
+      schema:
+        type: string
+        enum:
+          - no-store
+      description: no-store
+    RateLimitLimitHeader:
+      schema:
+        type: integer
+        format: int32
+        minimum: 0
+      description: Numero massimo richieste nell'intervallo di tempo.
+    RateLimitRemainingHeader:
+      schema:
+        type: integer
+        format: int32
+        minimum: 0
+      description: Richieste rimanenti nell'intervallo di tempo.
+    RateLimitResetHeader:
+      schema:
+        type: integer
+        format: int32
+        minimum: 0
+      description: UTC epoch in secondi, corrispondente a quando la finestra riferita al rate limit corrente effettuerà il reset.
+    RetryAfterHeader:
+      schema:
+        type: integer
+        format: int32
+        minimum: 0
+      description: Secondi da attendere prima di ricevere un'ulteriore risposta.
+    AgidJWTSignatureHeader:
+      schema:
+        type: string
+        format: JWT
+        example: eyJhbGc...1VrXfKTx-CUVz_puiwqkBhulrNKj2fA
+      description: JWT contenente la firma della risposta secondo il pattern INTEGRITY_REST_02 del ModI.
+    DigestHeader:
+      schema:
+        type: string
+        example: SHA-256=72e18bdddf13c911b4dd562ee21979a5c9f235c3a01bd1426e857d8c1a282f41
+      description: Digest del payload del messaggio di risposta secondo il pattern INTEGRITY_REST_02 del ModI.
+
+  securitySchemes:
+    bearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
+
+  schemas:
+    Problem:
+      type: object
+      title: Dettaglio esito chiamata
+      properties:
+        type:
+          type: string
+          description: Tipologia di errore o messaggio.
+        title:
+          type: string
+          description: Titolo sintetico dell'errore.
+        status:
+          type: integer
+          format: int32
+          minimum: 100
+          maximum: 599
+          description: Codice di stato HTTP associato.
+        detail:
+          type: string
+          description: Descrizione dettagliata dell'errore.
+        result:
+          type: object
+          description: Eventuale payload specifico dell'errore.
+        request_id:
+          type: string
+          description: Identificativo univoco della richiesta.
+      required:
+        - title
+        - status
+        - detail
+
+security:
+  - bearerAuth: []


### PR DESCRIPTION
This PR flattens the 'filtro' query object into individual parameters across OpenAPI examples. 

**Reasoning:**
GovWay (OpenSPCoop2) generates a 'ProtocolException: Trovato parametro query filtro senza tipo' when encountering complex objects in query parameters. Flattening these parameters ensures compatibility with the gateway while preserving the same HTTP message structure (e.g., ?tax_code=...).