### PR TITLE
docs: uniforma schema Problem a RFC 9457 in tutti gli OpenAPI

### DIFF
--- a/openapi/examples/Creazione EAA Tesserino Federazioni Sanitarie - IT Wallet.yaml
+++ b/openapi/examples/Creazione EAA Tesserino Federazioni Sanitarie - IT Wallet.yaml
@@ -45,7 +45,7 @@ paths:
             X-RateLimit-Reset: { $ref: "#/components/headers/RateLimitResetHeader" }
           content:
             application/problem+json:
-              schema: { $ref: "#/components/schemas/ProblemDetails" }
+              schema: { $ref: "#/components/schemas/Problem" }
         "401":
           description: Unauthorized
           headers:
@@ -55,21 +55,21 @@ paths:
             WWW-Authenticate: { $ref: "#/components/headers/WWWAuthenticateHeader" }
           content:
             application/problem+json:
-              schema: { $ref: "#/components/schemas/ProblemDetails" }
+              schema: { $ref: "#/components/schemas/Problem" }
         "429":
           description: Too Many Requests
           headers:
             Retry-After: { $ref: "#/components/headers/RetryAfterHeader" }
           content:
             application/problem+json:
-              schema: { $ref: "#/components/schemas/ProblemDetails" }
+              schema: { $ref: "#/components/schemas/Problem" }
         "503":
           description: Service Unavailable
           headers:
             Retry-After: { $ref: "#/components/headers/RetryAfterHeader" }
           content:
             application/problem+json:
-              schema: { $ref: "#/components/schemas/ProblemDetails" }
+              schema: { $ref: "#/components/schemas/Problem" }
 
   /attribute-claims/{datasetId}:
     post:
@@ -117,7 +117,7 @@ paths:
             X-RateLimit-Reset: { $ref: "#/components/headers/RateLimitResetHeader" }
           content:
             application/problem+json:
-              schema: { $ref: "#/components/schemas/ProblemDetails" }
+              schema: { $ref: "#/components/schemas/Problem" }
         "401":
           description: Unauthorized
           headers:
@@ -127,7 +127,7 @@ paths:
             WWW-Authenticate: { $ref: "#/components/headers/WWWAuthenticateHeader" }
           content:
             application/problem+json:
-              schema: { $ref: "#/components/schemas/ProblemDetails" }
+              schema: { $ref: "#/components/schemas/Problem" }
         "404":
           description: Claims not found
           headers:
@@ -136,28 +136,28 @@ paths:
             X-RateLimit-Reset: { $ref: "#/components/headers/RateLimitResetHeader" }
           content:
             application/problem+json:
-              schema: { $ref: "#/components/schemas/ProblemDetails" }
+              schema: { $ref: "#/components/schemas/Problem" }
         "429":
           description: Too Many Requests
           headers:
             Retry-After: { $ref: "#/components/headers/RetryAfterHeader" }
           content:
             application/problem+json:
-              schema: { $ref: "#/components/schemas/ProblemDetails" }
+              schema: { $ref: "#/components/schemas/Problem" }
         "500":
           description: Internal Server Error
           headers:
             Retry-After: { $ref: "#/components/headers/RetryAfterHeader" }
           content:
             application/problem+json:
-              schema: { $ref: "#/components/schemas/ProblemDetails" }
+              schema: { $ref: "#/components/schemas/Problem" }
         "503":
           description: Service Unavailable
           headers:
             Retry-After: { $ref: "#/components/headers/RetryAfterHeader" }
           content:
             application/problem+json:
-              schema: { $ref: "#/components/schemas/ProblemDetails" }
+              schema: { $ref: "#/components/schemas/Problem" }
 
 components:
   securitySchemes:
@@ -353,9 +353,9 @@ components:
                 format: date-time
                 example: "2025-01-15T10:30:00Z"
       required: [userClaims, attributeClaims, metadataClaims]
-    ProblemDetails:
+    Problem:
       type: object
-      description: Object conforming to RFC7807 for error reporting.
+      description: Object conforming to RFC 9457 for error reporting.
       properties:
         type:
           type: string

--- a/openapi/examples/accertamento_professionista.yaml
+++ b/openapi/examples/accertamento_professionista.yaml
@@ -319,33 +319,27 @@ components:
   schemas:
     Problem:
       type: object
-      title: Dettaglio esito chiamata
+      description: Oggetto conforme a RFC 9457 per la segnalazione degli errori.
       properties:
         type:
           type: string
-          description: Tipologia di errore o messaggio.
+          format: uri
+          description: URI assoluto che identifica il tipo di problema.
         title:
           type: string
-          description: Titolo sintetico dell'errore.
+          description: Breve riepilogo del tipo di problema.
         status:
           type: integer
           format: int32
-          minimum: 100
-          maximum: 599
-          description: Codice di stato HTTP associato.
+          description: Codice di stato HTTP generato per questa occorrenza del problema.
         detail:
           type: string
-          description: Descrizione dettagliata dell'errore.
-        result:
-          type: object
-          description: Eventuale payload specifico dell'errore.
-        request_id:
+          description: Spiegazione dettagliata specifica di questa occorrenza del problema.
+        instance:
           type: string
-          description: Identificativo univoco della richiesta.
-      required:
-        - title
-        - status
-        - detail
+          format: uri
+          description: URI assoluto che identifica l'occorrenza specifica del problema.
+      required: [title, status, detail]
 
     Person:
       type: object

--- a/openapi/examples/accertamento_status_professionista.yaml
+++ b/openapi/examples/accertamento_status_professionista.yaml
@@ -309,33 +309,27 @@ components:
   schemas:
     Problem:
       type: object
-      title: Dettaglio esito chiamata
+      description: Oggetto conforme a RFC 9457 per la segnalazione degli errori.
       properties:
         type:
           type: string
-          description: Tipologia di errore o messaggio.
+          format: uri
+          description: URI assoluto che identifica il tipo di problema.
         title:
           type: string
-          description: Titolo sintetico dell'errore.
+          description: Breve riepilogo del tipo di problema.
         status:
           type: integer
           format: int32
-          minimum: 100
-          maximum: 599
-          description: Codice di stato HTTP associato.
+          description: Codice di stato HTTP generato per questa occorrenza del problema.
         detail:
           type: string
-          description: Descrizione dettagliata dell'errore.
-        result:
-          type: object
-          description: Eventuale payload specifico dell'errore.
-        request_id:
+          description: Spiegazione dettagliata specifica di questa occorrenza del problema.
+        instance:
           type: string
-          description: Identificativo univoco della richiesta.
-      required:
-        - title
-        - status
-        - detail
+          format: uri
+          description: URI assoluto che identifica l'occorrenza specifica del problema.
+      required: [title, status, detail]
 
 security:
   - bearerAuth: []

--- a/openapi/examples/govway/ITWallet_Albo.yaml
+++ b/openapi/examples/govway/ITWallet_Albo.yaml
@@ -45,7 +45,7 @@ paths:
             X-RateLimit-Reset: { $ref: "#/components/headers/RateLimitResetHeader" }
           content:
             application/problem+json:
-              schema: { $ref: "#/components/schemas/ProblemDetails" }
+              schema: { $ref: "#/components/schemas/Problem" }
         "401":
           description: Unauthorized
           headers:
@@ -55,21 +55,21 @@ paths:
             WWW-Authenticate: { $ref: "#/components/headers/WWWAuthenticateHeader" }
           content:
             application/problem+json:
-              schema: { $ref: "#/components/schemas/ProblemDetails" }
+              schema: { $ref: "#/components/schemas/Problem" }
         "429":
           description: Too Many Requests
           headers:
             Retry-After: { $ref: "#/components/headers/RetryAfterHeader" }
           content:
             application/problem+json:
-              schema: { $ref: "#/components/schemas/ProblemDetails" }
+              schema: { $ref: "#/components/schemas/Problem" }
         "503":
           description: Service Unavailable
           headers:
             Retry-After: { $ref: "#/components/headers/RetryAfterHeader" }
           content:
             application/problem+json:
-              schema: { $ref: "#/components/schemas/ProblemDetails" }
+              schema: { $ref: "#/components/schemas/Problem" }
 
   /attribute-claims/{datasetId}:
     post:
@@ -117,7 +117,7 @@ paths:
             X-RateLimit-Reset: { $ref: "#/components/headers/RateLimitResetHeader" }
           content:
             application/problem+json:
-              schema: { $ref: "#/components/schemas/ProblemDetails" }
+              schema: { $ref: "#/components/schemas/Problem" }
         "401":
           description: Unauthorized
           headers:
@@ -127,7 +127,7 @@ paths:
             WWW-Authenticate: { $ref: "#/components/headers/WWWAuthenticateHeader" }
           content:
             application/problem+json:
-              schema: { $ref: "#/components/schemas/ProblemDetails" }
+              schema: { $ref: "#/components/schemas/Problem" }
         "404":
           description: Claims not found
           headers:
@@ -136,28 +136,28 @@ paths:
             X-RateLimit-Reset: { $ref: "#/components/headers/RateLimitResetHeader" }
           content:
             application/problem+json:
-              schema: { $ref: "#/components/schemas/ProblemDetails" }
+              schema: { $ref: "#/components/schemas/Problem" }
         "429":
           description: Too Many Requests
           headers:
             Retry-After: { $ref: "#/components/headers/RetryAfterHeader" }
           content:
             application/problem+json:
-              schema: { $ref: "#/components/schemas/ProblemDetails" }
+              schema: { $ref: "#/components/schemas/Problem" }
         "500":
           description: Internal Server Error
           headers:
             Retry-After: { $ref: "#/components/headers/RetryAfterHeader" }
           content:
             application/problem+json:
-              schema: { $ref: "#/components/schemas/ProblemDetails" }
+              schema: { $ref: "#/components/schemas/Problem" }
         "503":
           description: Service Unavailable
           headers:
             Retry-After: { $ref: "#/components/headers/RetryAfterHeader" }
           content:
             application/problem+json:
-              schema: { $ref: "#/components/schemas/ProblemDetails" }
+              schema: { $ref: "#/components/schemas/Problem" }
 
 components:
   securitySchemes:
@@ -323,9 +323,9 @@ components:
                 format: date-time
                 example: "2025-01-15T10:30:00Z"
       required: [userClaims, attributeClaims, metadataClaims]
-    ProblemDetails:
+    Problem:
       type: object
-      description: Object conforming to RFC7807 for error reporting.
+      description: Object conforming to RFC 9457 for error reporting.
       properties:
         type:
           type: string

--- a/openapi/examples/govway/accertamento_professionista.yaml
+++ b/openapi/examples/govway/accertamento_professionista.yaml
@@ -288,33 +288,27 @@ components:
   schemas:
     Problem:
       type: object
-      title: Dettaglio esito chiamata
+      description: Oggetto conforme a RFC 9457 per la segnalazione degli errori.
       properties:
         type:
           type: string
-          description: Tipologia di errore o messaggio.
+          format: uri
+          description: URI assoluto che identifica il tipo di problema.
         title:
           type: string
-          description: Titolo sintetico dell'errore.
+          description: Breve riepilogo del tipo di problema.
         status:
           type: integer
           format: int32
-          minimum: 100
-          maximum: 599
-          description: Codice di stato HTTP associato.
+          description: Codice di stato HTTP generato per questa occorrenza del problema.
         detail:
           type: string
-          description: Descrizione dettagliata dell'errore.
-        result:
-          type: object
-          description: Eventuale payload specifico dell'errore.
-        request_id:
+          description: Spiegazione dettagliata specifica di questa occorrenza del problema.
+        instance:
           type: string
-          description: Identificativo univoco della richiesta.
-      required:
-        - title
-        - status
-        - detail
+          format: uri
+          description: URI assoluto che identifica l'occorrenza specifica del problema.
+      required: [title, status, detail]
 
     Person:
       type: object

--- a/openapi/examples/govway/accertamento_status_professionista.yaml
+++ b/openapi/examples/govway/accertamento_status_professionista.yaml
@@ -281,33 +281,27 @@ components:
   schemas:
     Problem:
       type: object
-      title: Dettaglio esito chiamata
+      description: Oggetto conforme a RFC 9457 per la segnalazione degli errori.
       properties:
         type:
           type: string
-          description: Tipologia di errore o messaggio.
+          format: uri
+          description: URI assoluto che identifica il tipo di problema.
         title:
           type: string
-          description: Titolo sintetico dell'errore.
+          description: Breve riepilogo del tipo di problema.
         status:
           type: integer
           format: int32
-          minimum: 100
-          maximum: 599
-          description: Codice di stato HTTP associato.
+          description: Codice di stato HTTP generato per questa occorrenza del problema.
         detail:
           type: string
-          description: Descrizione dettagliata dell'errore.
-        result:
-          type: object
-          description: Eventuale payload specifico dell'errore.
-        request_id:
+          description: Spiegazione dettagliata specifica di questa occorrenza del problema.
+        instance:
           type: string
-          description: Identificativo univoco della richiesta.
-      required:
-        - title
-        - status
-        - detail
+          format: uri
+          description: URI assoluto che identifica l'occorrenza specifica del problema.
+      required: [title, status, detail]
 
 security:
   - bearerAuth: []

--- a/openapi/examples/govway/verifica_status_professionista.yaml
+++ b/openapi/examples/govway/verifica_status_professionista.yaml
@@ -282,33 +282,27 @@ components:
   schemas:
     Problem:
       type: object
-      title: Dettaglio esito chiamata
+      description: Oggetto conforme a RFC 9457 per la segnalazione degli errori.
       properties:
         type:
           type: string
-          description: Tipologia di errore o messaggio.
+          format: uri
+          description: URI assoluto che identifica il tipo di problema.
         title:
           type: string
-          description: Titolo sintetico dell'errore.
+          description: Breve riepilogo del tipo di problema.
         status:
           type: integer
           format: int32
-          minimum: 100
-          maximum: 599
-          description: Codice di stato HTTP associato.
+          description: Codice di stato HTTP generato per questa occorrenza del problema.
         detail:
           type: string
-          description: Descrizione dettagliata dell'errore.
-        result:
-          type: object
-          description: Eventuale payload specifico dell'errore.
-        request_id:
+          description: Spiegazione dettagliata specifica di questa occorrenza del problema.
+        instance:
           type: string
-          description: Identificativo univoco della richiesta.
-      required:
-        - title
-        - status
-        - detail
+          format: uri
+          description: URI assoluto che identifica l'occorrenza specifica del problema.
+      required: [title, status, detail]
 
 security:
   - bearerAuth: []

--- a/openapi/examples/verifica_status_professionista.yaml
+++ b/openapi/examples/verifica_status_professionista.yaml
@@ -310,33 +310,27 @@ components:
   schemas:
     Problem:
       type: object
-      title: Dettaglio esito chiamata
+      description: Oggetto conforme a RFC 9457 per la segnalazione degli errori.
       properties:
         type:
           type: string
-          description: Tipologia di errore o messaggio.
+          format: uri
+          description: URI assoluto che identifica il tipo di problema.
         title:
           type: string
-          description: Titolo sintetico dell'errore.
+          description: Breve riepilogo del tipo di problema.
         status:
           type: integer
           format: int32
-          minimum: 100
-          maximum: 599
-          description: Codice di stato HTTP associato.
+          description: Codice di stato HTTP generato per questa occorrenza del problema.
         detail:
           type: string
-          description: Descrizione dettagliata dell'errore.
-        result:
-          type: object
-          description: Eventuale payload specifico dell'errore.
-        request_id:
+          description: Spiegazione dettagliata specifica di questa occorrenza del problema.
+        instance:
           type: string
-          description: Identificativo univoco della richiesta.
-      required:
-        - title
-        - status
-        - detail
+          format: uri
+          description: URI assoluto che identifica l'occorrenza specifica del problema.
+      required: [title, status, detail]
 
 security:
   - bearerAuth: []


### PR DESCRIPTION
## Summary

- Rinomina `ProblemDetails` → `Problem` nei file IT Wallet per uniformare il nome in tutti gli OpenAPI
- Allinea il contenuto dello schema `Problem` a RFC 9457 in tutti e 8 i file: aggiunge `instance`, rimuove `result` e `request_id`, aggiunge `format: uri` su `type`, rimuove `minimum`/`maximum` su `status`
- Descrizioni in italiano nei 6 yaml non-IT Wallet, in inglese nei 2 yaml IT Wallet